### PR TITLE
Editing of 2025 and 2026 GCE O- and A-Level syllabus documents 

### DIFF
--- a/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
+++ b/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
@@ -1219,7 +1219,9 @@ H3 Chemistry (9813) syllabus.&nbsp;</p>
 <p>9901</p>
 </td>
 <td rowspan="1" colspan="1">
-<p>-</p>
+<p><a href="/files/A Level Syllabus Sch Cddts/2026/9901_y26_sp1.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 1</u></a>
+<br><a href="/files/A Level Syllabus Sch Cddts/2026/9901_y26_sp2.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 2</u></a>
+<br>[2026]</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Hi all

I have also edited the 2025 and 2026 GCE O- and A-Level syllabus documents under the same review request.

Do note that Jye Yuin has clarified that GCE O-Level Chinese (Special Programme) (1166) should not be uploaded on the 2025 and 2026 GCE O-Level private candidate pages.

