### PR TITLE
Update to approved calculators link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -70,7 +70,7 @@ links:
       - title: Past Years' Results
         url: /statements-of-results
       - title: Approved Calculators
-        url: https://go.gov.sg/guidelines-calculators
+        url: https://go.gov.sg/seab-approvedcalculators
       - title: Approved Dictionaries
         url: https://go.gov.sg/list-of-dictionaries-for-examination
   - title: FAQs


### PR DESCRIPTION
We have updated the approved calculators link in the quick links drop down list of the website's navigation bar.