### PR TITLE
Removal of space between link and a word in a page

### DIFF
--- a/pages/Updates for Private Candidates.md
+++ b/pages/Updates for Private Candidates.md
@@ -10,8 +10,7 @@ GCE-Level examinations will commence from <strong>2 April 2025 (Wednesday), 9.00
 will be via the<a href="https://myexams.seab.gov.sg/auth/login" rel="noopener noreferrer nofollow" target="_blank"> Candidates Portal</a>.</p>
 <p>Key information about the eligibility criteria, registration guidelines,
 procedures and examination fees are presented below. You should read the
-<a href="https://go.gov.sg/registration-information-for-private-candidates" rel="noopener nofollow" target="_blank">Registration Information e-booklet</a><a href="https://go.gov.sg/registration-information-for-private-candidates" rel="noopener noreferrer nofollow" target="_blank"> </a>for
-the details.</p>
+<a href="https://go.gov.sg/registration-information-for-private-candidates" rel="noopener nofollow" target="_blank">Registration Information e-booklet</a>for the details.</p>
 <div data-type="detailGroup" class="isomer-accordion isomer-accordion-white">
 <details class="isomer-details">
 <summary><strong>ELIGIBILITY CRITERIA AND REGISTRATION GUIDELINES</strong>


### PR DESCRIPTION
I have removed a space between the link to the 2025 Registration Information e-booklet and the word 'for' in the private candidates' registration exercise page.