### PR TITLE
A broken link to the GCE A-Level (8879) syllabus document for school candidates has been fixed.

### DIFF
--- a/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
+++ b/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
@@ -350,7 +350,7 @@ from SEAB.</p>
 </tr>
 <tr>
 <td rowspan="1" colspan="1">
-<p><a href="/files/A Level Syllabus Sch Cddts/2026/8879_y26_sy.pdf" rel="noopener noreferrer nofollow" target="_blank">Art</a> [Revised]</p>
+<p><a href="/files/A Level Syllabus Sch Cddts/2026/8879_y26_sy_v0_4.pdf" rel="noopener noreferrer nofollow" target="_blank">Art</a> [Revised]</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>English</p>


### PR DESCRIPTION
A broken link to the GCE A-Level (8879) syllabus document for school candidates has been fixed.