### PR TITLE
EOD has asked for the removal of another instance of this sentence from the past years' examination results page: , or a document from the Immigration Checkpoints Authority certifying that the identification number is tied to you

### DIFF
--- a/pages/Past Years' Results in Digital Form.md
+++ b/pages/Past Years' Results in Digital Form.md
@@ -97,8 +97,7 @@ results at no cost:</p>
 </li>
 <li>
 <p>Front and back of the identification document that you have used to sit
-for the examination, or a document from the Immigration Checkpoints Authority
-certifying that the identification number is tied to you</p>
+for the examination</p>
 </li>
 <li>
 <p>School Name</p>


### PR DESCRIPTION
EOD has asked for the removal of another instance of this sentence from the past years' examination results page: , or a document from the Immigration Checkpoints Authority certifying that the identification number is tied to you