### PR TITLE
The links to the data file for the 2026 GCE A-Level H2 Physics (9478) syllabuses for school and private candidates has been updated.

### DIFF
--- a/pages/2026 GCE Advanced Level Syllabuses Examined for Private Candidates.md
+++ b/pages/2026 GCE Advanced Level Syllabuses Examined for Private Candidates.md
@@ -671,7 +671,7 @@ understand the revised examination format.</p>
 <br><a href="/files/A Level Syllabus Private Cddts/2026/9478_y26_sp_2.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 2</u></a>
 <br><a href="/files/A Level Syllabus Private Cddts/2026/9478_y26_sp_3.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 3</u></a>
 <br><a href="/files/A Level Syllabus Private Cddts/2026/9478_y26_sp_4.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 4</u></a>
-<br><a href="https://go.gov.sg/h2physics9478paper4q2bdataset" rel="noopener nofollow" target="_blank">Data File</a>
+<br><a href="https://go.gov.sg/datasetq2b" rel="noopener nofollow" target="_blank">Data File</a>
 <br><a href="/files/A Level Syllabus Private Cddts/2026/SEAB_9478_Physics_Excel_Reference_Guide_2026_v0_3.pdf" rel="noopener noreferrer nofollow" target="_blank">Excel Reference Guide</a>
 <br>[2025]</p>
 </td>

--- a/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
+++ b/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
@@ -1509,4 +1509,5 @@ H3 Chemistry (9813) syllabus.&nbsp;</p>
 </tr>
 </tbody>
 </table>
-<p></p>
+<p><a href="https://go.gov.sg/datasetq2b" rel="noopener nofollow" target="_blank">Data File</a>
+</p>

--- a/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
+++ b/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
@@ -1509,5 +1509,4 @@ H3 Chemistry (9813) syllabus.&nbsp;</p>
 </tr>
 </tbody>
 </table>
-<p><a href="https://go.gov.sg/datasetq2b" rel="noopener nofollow" target="_blank">Data File</a>
-</p>
+<p></p>

--- a/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
+++ b/pages/2026 GCE Advanced Level Syllabuses Examined for School Candidates.md
@@ -499,7 +499,7 @@ from SEAB.</p>
 <br><a href="/files/A Level Syllabus Sch Cddts/2026/9478_y26_sp_2.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 2</u></a>
 <br><a href="/files/A Level Syllabus Sch Cddts/2026/9478_y26_sp_3.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 3</u></a>
 <br><a href="/files/A Level Syllabus Sch Cddts/2026/9478_y26_sp_4.pdf" rel="noopener noreferrer nofollow" target="_blank"><u>Paper 4</u></a>
-<br><a href="https://go.gov.sg/h2physics9478paper4q2bdataset" rel="noopener nofollow" target="_blank">Data File</a>
+<br><a href="https://go.gov.sg/datasetq2b" rel="noopener nofollow" target="_blank">Data File</a>
 <br><a href="/files/A Level Syllabus Sch Cddts/2026/SEAB_9478_Physics_Excel_Reference_Guide_2026_v0_3.pdf" rel="noopener noreferrer nofollow" target="_blank">Excel Reference Guide</a>
 <br>[2025]</p>
 </td>

--- a/pages/Important Dates for Candidates.md
+++ b/pages/Important Dates for Candidates.md
@@ -175,7 +175,7 @@ image: /images/HomePage/SEAB_logo_topbar.png
 <p>25 February – 27 February 2026</p>
 </td>
 <td rowspan="1" colspan="1">
-<p>21 August – 25 August 2025</p>
+<p>21 August 2025</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
The links to the data file for the 2026 GCE A-Level H2 Physics (9478) syllabuses for school and private candidates has been updated.